### PR TITLE
Fix checkout modal and RSVP database util

### DIFF
--- a/premium-event-ticketing/package.json
+++ b/premium-event-ticketing/package.json
@@ -23,7 +23,8 @@
     "react": "latest",
     "react-dom": "latest",
     "axios": "^0.21.1",
-    "stripe": "^8.0.0"
+    "stripe": "^8.0.0",
+    "mongodb": "^5.7.0"
   },
   "devDependencies": {
     "typescript": "latest",

--- a/premium-event-ticketing/src/components/CheckoutModal.tsx
+++ b/premium-event-ticketing/src/components/CheckoutModal.tsx
@@ -41,7 +41,7 @@ const CheckoutModal: React.FC<CheckoutModalProps> = ({ isOpen, onClose, ticketTi
   if (!isOpen) return null;
 
   return (
-    <div className="modal-overlay">
+    <div className="modal">
       <div className="modal-content">
         <button className="close" onClick={onClose}>&times;</button>
         <h2>Checkout - {ticketTier} (${price})</h2>

--- a/premium-event-ticketing/src/components/TicketTiers.tsx
+++ b/premium-event-ticketing/src/components/TicketTiers.tsx
@@ -7,7 +7,11 @@ interface TicketTier {
   remaining: number;
 }
 
-const TicketTiers: React.FC = () => {
+interface TicketTiersProps {
+  onSelect: (tier: TicketTier) => void;
+}
+
+const TicketTiers: React.FC<TicketTiersProps> = ({ onSelect }) => {
   const [ticketTiers, setTicketTiers] = useState<TicketTier[]>([]);
 
   useEffect(() => {
@@ -21,8 +25,7 @@ const TicketTiers: React.FC = () => {
   }, []);
 
   const handleSelect = (tier: TicketTier) => {
-    // Logic to handle ticket selection
-    console.log(`Selected ${tier.name} ticket`);
+    onSelect(tier);
   };
 
   return (

--- a/premium-event-ticketing/src/pages/api/checkout.ts
+++ b/premium-event-ticketing/src/pages/api/checkout.ts
@@ -2,7 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import Stripe from 'stripe';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
-  apiVersion: '2025-06-30.basil',
+  apiVersion: '2022-11-15',
 });
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {

--- a/premium-event-ticketing/src/pages/api/inventory.ts
+++ b/premium-event-ticketing/src/pages/api/inventory.ts
@@ -1,9 +1,24 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 const inventory = [
-  { tier: 'General Admission', price: 150, remaining: 100 },
-  { tier: 'VIP', price: 300, remaining: 50 },
-  { tier: 'Ultra', price: 600, remaining: 20 },
+  {
+    name: 'General Admission',
+    price: 150,
+    remaining: 100,
+    perks: ['Entry to event', 'Complimentary drink'],
+  },
+  {
+    name: 'VIP',
+    price: 300,
+    remaining: 50,
+    perks: ['All General perks', 'VIP lounge access', 'Expedited entry'],
+  },
+  {
+    name: 'Ultra',
+    price: 600,
+    remaining: 20,
+    perks: ['All VIP perks', 'Table service', 'Meet & Greet'],
+  },
 ];
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {

--- a/premium-event-ticketing/src/pages/api/rsvp.ts
+++ b/premium-event-ticketing/src/pages/api/rsvp.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 // Update the import path to the correct location of connectToDatabase
-import { connectToDatabase } from '../../../utils/db';
+import { connectToDatabase } from '../../utils/db';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'POST') {

--- a/premium-event-ticketing/src/pages/index.tsx
+++ b/premium-event-ticketing/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Header from '../components/Header';
 import Hero from '../components/Hero';
 import Gallery from '../components/Gallery';
@@ -8,18 +8,28 @@ import RSVPForm from '../components/RSVPForm';
 import Footer from '../components/Footer';
 
 const HomePage = () => {
+  const [selectedTier, setSelectedTier] = useState<{ name: string; price: number } | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const handleSelect = (tier: { name: string; price: number }) => {
+    setSelectedTier(tier);
+    setIsModalOpen(true);
+  };
+
   return (
     <div>
       <Header />
       <Hero />
       <Gallery />
-      <TicketTiers />
-      <CheckoutModal
-        isOpen={false}
-        onClose={() => {}}
-        ticketTier=""
-        price={0}
-      />
+      <TicketTiers onSelect={handleSelect} />
+      {selectedTier && (
+        <CheckoutModal
+          isOpen={isModalOpen}
+          onClose={() => setIsModalOpen(false)}
+          ticketTier={selectedTier.name}
+          price={selectedTier.price}
+        />
+      )}
       <RSVPForm />
       <Footer />
     </div>

--- a/premium-event-ticketing/src/utils/db.ts
+++ b/premium-event-ticketing/src/utils/db.ts
@@ -1,0 +1,20 @@
+import { MongoClient, Db } from 'mongodb';
+
+let client: MongoClient | null = null;
+let db: Db | null = null;
+
+export async function connectToDatabase(): Promise<Db> {
+  const uri = process.env.MONGODB_URI;
+  if (!uri) {
+    throw new Error('Please define the MONGODB_URI environment variable');
+  }
+
+  if (client && db) {
+    return db;
+  }
+
+  client = new MongoClient(uri);
+  await client.connect();
+  db = client.db();
+  return db;
+}


### PR DESCRIPTION
## Summary
- add MongoDB helper
- wire up ticket tier selection to the checkout modal
- fix modal CSS class and inventory API format
- update Stripe version and RSVP database import
- add mongodb dependency

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: missing ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_6869845e22e48324a38d5262c8455dbb