### PR TITLE
Add Stripe checkout integration

### DIFF
--- a/premium-event-ticketing/package.json
+++ b/premium-event-ticketing/package.json
@@ -24,6 +24,7 @@
     "react-dom": "latest",
     "axios": "^0.21.1",
     "stripe": "^8.0.0",
+    "@stripe/stripe-js": "^1.50.0",
     "mongodb": "^5.7.0"
   },
   "devDependencies": {

--- a/premium-event-ticketing/src/components/CheckoutButton.tsx
+++ b/premium-event-ticketing/src/components/CheckoutButton.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { loadStripe } from '@stripe/stripe-js';
+
+interface CheckoutButtonProps {
+  ticketData: { stripe_price_id: string; email: string };
+  children?: React.ReactNode;
+}
+
+const stripePromise = loadStripe(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY!);
+
+const CheckoutButton: React.FC<CheckoutButtonProps> = ({ ticketData, children }) => {
+  const handleCheckout = async () => {
+    const res = await fetch('/api/checkout', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        items: [{ price: ticketData.stripe_price_id, quantity: 1 }],
+        email: ticketData.email,
+      }),
+    });
+
+    const { id } = await res.json();
+    const stripe = await stripePromise;
+    stripe?.redirectToCheckout({ sessionId: id });
+  };
+
+  return (
+    <button className="btn primary" onClick={handleCheckout}>
+      {children || 'Buy Ticket'}
+    </button>
+  );
+};
+
+export default CheckoutButton;

--- a/premium-event-ticketing/src/components/CheckoutModal.tsx
+++ b/premium-event-ticketing/src/components/CheckoutModal.tsx
@@ -1,13 +1,15 @@
 import React, { useState } from 'react';
+import CheckoutButton from './CheckoutButton';
 
 interface CheckoutModalProps {
   isOpen: boolean;
   onClose: () => void;
   ticketTier: string;
   price: number;
+  stripePriceId: string;
 }
 
-const CheckoutModal: React.FC<CheckoutModalProps> = ({ isOpen, onClose, ticketTier, price }) => {
+const CheckoutModal: React.FC<CheckoutModalProps> = ({ isOpen, onClose, ticketTier, price, stripePriceId }) => {
   const [formData, setFormData] = useState({
     name: '',
     email: '',
@@ -19,23 +21,8 @@ const CheckoutModal: React.FC<CheckoutModalProps> = ({ isOpen, onClose, ticketTi
     setFormData({ ...formData, [name]: value });
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    // Call the checkout API with formData and ticketTier
-    const response = await fetch('/api/checkout', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ ...formData, ticketTier, price }),
-    });
-
-    if (response.ok) {
-      alert('Payment processed successfully!');
-      onClose();
-    } else {
-      alert('There was an error processing your payment.');
-    }
   };
 
   if (!isOpen) return null;
@@ -55,7 +42,11 @@ const CheckoutModal: React.FC<CheckoutModalProps> = ({ isOpen, onClose, ticketTi
           <label htmlFor="phone">Phone</label>
           <input type="tel" id="phone" name="phone" value={formData.phone} onChange={handleChange} required />
           
-          <button type="submit" className="btn primary">Pay Now</button>
+          <CheckoutButton
+            ticketData={{ stripe_price_id: stripePriceId, email: formData.email }}
+          >
+            Pay Now
+          </CheckoutButton>
           <p className="note">Secure payment processing placeholder</p>
         </form>
       </div>

--- a/premium-event-ticketing/src/components/TicketTiers.tsx
+++ b/premium-event-ticketing/src/components/TicketTiers.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 
 interface TicketTier {
   name: string;
+  stripe_price_id: string;
   price: number;
   perks: string[];
   remaining: number;

--- a/premium-event-ticketing/src/pages/api/inventory.ts
+++ b/premium-event-ticketing/src/pages/api/inventory.ts
@@ -3,18 +3,21 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 const inventory = [
   {
     name: 'General Admission',
+    stripe_price_id: 'price_general',
     price: 150,
     remaining: 100,
     perks: ['Entry to event', 'Complimentary drink'],
   },
   {
     name: 'VIP',
+    stripe_price_id: 'price_vip',
     price: 300,
     remaining: 50,
     perks: ['All General perks', 'VIP lounge access', 'Expedited entry'],
   },
   {
     name: 'Ultra',
+    stripe_price_id: 'price_ultra',
     price: 600,
     remaining: 20,
     perks: ['All VIP perks', 'Table service', 'Meet & Greet'],

--- a/premium-event-ticketing/src/pages/cancel.tsx
+++ b/premium-event-ticketing/src/pages/cancel.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const CancelPage = () => {
+  return (
+    <div className="cancel-page fade-in">
+      <h1>Payment Cancelled</h1>
+      <p>Your payment was cancelled. You can return to the event page to try again.</p>
+    </div>
+  );
+};
+
+export default CancelPage;

--- a/premium-event-ticketing/src/pages/index.tsx
+++ b/premium-event-ticketing/src/pages/index.tsx
@@ -8,10 +8,10 @@ import RSVPForm from '../components/RSVPForm';
 import Footer from '../components/Footer';
 
 const HomePage = () => {
-  const [selectedTier, setSelectedTier] = useState<{ name: string; price: number } | null>(null);
+  const [selectedTier, setSelectedTier] = useState<{ name: string; price: number; stripe_price_id: string } | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const handleSelect = (tier: { name: string; price: number }) => {
+  const handleSelect = (tier: { name: string; price: number; stripe_price_id: string }) => {
     setSelectedTier(tier);
     setIsModalOpen(true);
   };
@@ -28,6 +28,7 @@ const HomePage = () => {
           onClose={() => setIsModalOpen(false)}
           ticketTier={selectedTier.name}
           price={selectedTier.price}
+          stripePriceId={selectedTier.stripe_price_id}
         />
       )}
       <RSVPForm />

--- a/premium-event-ticketing/src/pages/success.tsx
+++ b/premium-event-ticketing/src/pages/success.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const SuccessPage = () => {
+  return (
+    <div className="success-page fade-in">
+      <h1>Purchase Successful!</h1>
+      <p>Thank you for your purchase. A confirmation email has been sent.</p>
+    </div>
+  );
+};
+
+export default SuccessPage;

--- a/premium-event-ticketing/src/types/index.ts
+++ b/premium-event-ticketing/src/types/index.ts
@@ -3,6 +3,7 @@
 export interface TicketTier {
   id: string;
   name: string;
+  stripe_price_id?: string;
   price: number;
   perks: string[];
   remaining: number;


### PR DESCRIPTION
## Summary
- add `@stripe/stripe-js` dependency
- expose Stripe price IDs via API
- implement `CheckoutButton` with Stripe redirect logic
- wire up button inside `CheckoutModal`
- pass Stripe price ID through ticket tier components
- add purchase success and cancel fallback pages

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_686a917a3fec8324ab73e72bb891ad4c