### PR TITLE
Implement event routing and admin

### DIFF
--- a/premium-event-ticketing/src/hooks/useAuth.ts
+++ b/premium-event-ticketing/src/hooks/useAuth.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react'
+import { auth } from '../lib/firebaseClient'
+import { onAuthStateChanged, User } from 'firebase/auth'
+
+export function useAuth() {
+  const [user, setUser] = useState<User | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const unsub = onAuthStateChanged(auth, (u) => {
+      setUser(u)
+      setLoading(false)
+    })
+    return () => unsub()
+  }, [])
+
+  return { user, loading }
+}

--- a/premium-event-ticketing/src/hooks/withAuth.tsx
+++ b/premium-event-ticketing/src/hooks/withAuth.tsx
@@ -1,0 +1,17 @@
+import { useAuth } from './useAuth'
+import { useRouter } from 'next/router'
+import React from 'react'
+
+export function withAuth<T>(Component: React.ComponentType<T>) {
+  return function ProtectedComponent(props: T) {
+    const { user, loading } = useAuth()
+    const router = useRouter()
+
+    if (loading) return null
+    if (!user) {
+      router.push('/')
+      return null
+    }
+    return <Component {...props} />
+  }
+}

--- a/premium-event-ticketing/src/lib/firebaseAdmin.ts
+++ b/premium-event-ticketing/src/lib/firebaseAdmin.ts
@@ -1,0 +1,16 @@
+import admin from 'firebase-admin'
+
+const privateKey = process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n')
+
+if (!admin.apps.length) {
+  admin.initializeApp({
+    credential: admin.credential.cert({
+      projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+      clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
+      privateKey,
+    }),
+  })
+}
+
+export const firestore = admin.firestore()
+export const auth = admin.auth()

--- a/premium-event-ticketing/src/lib/firebaseClient.ts
+++ b/premium-event-ticketing/src/lib/firebaseClient.ts
@@ -1,0 +1,25 @@
+// src/lib/firebaseClient.ts
+import { initializeApp, getApps, getApp } from 'firebase/app'
+import { getAuth } from 'firebase/auth'
+import { getAnalytics, isSupported } from 'firebase/analytics'
+
+const firebaseConfig = {
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+  measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID,
+}
+
+const app = getApps().length === 0 ? initializeApp(firebaseConfig) : getApp()
+const auth = getAuth(app)
+
+if (typeof window !== 'undefined') {
+  isSupported().then((supported) => {
+    if (supported) getAnalytics(app)
+  })
+}
+
+export { app, auth }

--- a/premium-event-ticketing/src/lib/stripe.ts
+++ b/premium-event-ticketing/src/lib/stripe.ts
@@ -1,0 +1,5 @@
+import Stripe from 'stripe'
+
+export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
+  apiVersion: '2022-11-15',
+})

--- a/premium-event-ticketing/src/pages/[slug].tsx
+++ b/premium-event-ticketing/src/pages/[slug].tsx
@@ -1,0 +1,80 @@
+import { GetStaticPaths, GetStaticProps } from 'next'
+import { useRouter } from 'next/router'
+import CheckoutModal from '../components/CheckoutModal'
+import TicketTiers from '../components/TicketTiers'
+import Header from '../components/Header'
+import Footer from '../components/Footer'
+import { firestore } from '../lib/firebaseAdmin'
+import { useState } from 'react'
+
+interface TicketTier {
+  id: string
+  name: string
+  price: number
+  stripe_price_id: string
+  perks: string[]
+}
+
+interface EventPageProps {
+  event: {
+    id: string
+    title: string
+    location: string
+    image: string
+    ticketTiers: TicketTier[]
+  }
+}
+
+export default function EventPage({ event }: EventPageProps) {
+  const [selectedTier, setSelectedTier] = useState<TicketTier | null>(null)
+  const [open, setOpen] = useState(false)
+  const router = useRouter()
+
+  if (router.isFallback) return <div>Loading...</div>
+
+  return (
+    <div>
+      <Header />
+      <section className="event-hero">
+        <img src={event.image} alt={event.title} />
+        <h1>{event.title}</h1>
+        <p>{event.location}</p>
+      </section>
+      <TicketTiers
+        onSelect={(tier) => {
+          setSelectedTier(tier as TicketTier)
+          setOpen(true)
+        }}
+      />
+      {selectedTier && (
+        <CheckoutModal
+          isOpen={open}
+          onClose={() => setOpen(false)}
+          ticketTier={selectedTier.name}
+          price={selectedTier.price}
+          stripePriceId={selectedTier.stripe_price_id}
+        />
+      )}
+      <Footer />
+    </div>
+  )
+}
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const snapshot = await firestore.collection('events').get()
+  const paths = snapshot.docs.map((doc) => ({ params: { slug: doc.id } }))
+  return { paths, fallback: true }
+}
+
+export const getStaticProps: GetStaticProps = async ({ params }) => {
+  const slug = params?.slug as string
+  const doc = await firestore.collection('events').doc(slug).get()
+  const event = doc.data() || null
+  if (!event) return { notFound: true }
+  return {
+    props: {
+      event: { id: doc.id, ...event },
+    },
+    revalidate: 60,
+  }
+}

--- a/premium-event-ticketing/src/pages/[slug]/admin.tsx
+++ b/premium-event-ticketing/src/pages/[slug]/admin.tsx
@@ -1,0 +1,32 @@
+import { withAuth } from '../../hooks/withAuth'
+import { firestore } from '../../lib/firebaseAdmin'
+import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
+
+function AdminPage() {
+  const router = useRouter()
+  const { slug } = router.query
+  const [orders, setOrders] = useState<any[]>([])
+
+  useEffect(() => {
+    if (!slug) return
+    firestore
+      .collection('orders')
+      .where('eventId', '==', slug)
+      .get()
+      .then((snap) => setOrders(snap.docs.map((d) => d.data())))
+  }, [slug])
+
+  return (
+    <div>
+      <h1>Event Admin</h1>
+      <ul>
+        {orders.map((o, i) => (
+          <li key={i}>{o.email} - {o.quantity}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+export default withAuth(AdminPage)

--- a/premium-event-ticketing/src/pages/api/webhook.ts
+++ b/premium-event-ticketing/src/pages/api/webhook.ts
@@ -1,0 +1,48 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { stripe } from '../../lib/stripe'
+import { firestore } from '../../lib/firebaseAdmin'
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST')
+    return res.status(405).end('Method Not Allowed')
+  }
+
+  const buf = await new Promise<Buffer>((resolve, reject) => {
+    const chunks: Buffer[] = []
+    req.on('data', (chunk) => chunks.push(chunk))
+    req.on('end', () => resolve(Buffer.concat(chunks)))
+    req.on('error', reject)
+  })
+
+  const sig = req.headers['stripe-signature'] as string
+
+  let event
+
+  try {
+    event = stripe.webhooks.constructEvent(
+      buf,
+      sig,
+      process.env.STRIPE_WEBHOOK_SECRET as string
+    )
+  } catch (err) {
+    return res.status(400).send(`Webhook Error: ${(err as Error).message}`)
+  }
+
+  if (event.type === 'checkout.session.completed') {
+    const session = event.data.object as any
+    await firestore.collection('orders').add({
+      eventId: session.metadata?.eventId,
+      email: session.customer_details?.email,
+      quantity: session.amount_total / 100,
+    })
+  }
+
+  res.json({ received: true })
+}

--- a/premium-event-ticketing/src/pages/dashboard/index.tsx
+++ b/premium-event-ticketing/src/pages/dashboard/index.tsx
@@ -1,0 +1,30 @@
+import { withAuth } from '../../hooks/withAuth'
+import { firestore } from '../../lib/firebaseAdmin'
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+
+function Dashboard() {
+  const [events, setEvents] = useState<any[]>([])
+
+  useEffect(() => {
+    firestore
+      .collection('events')
+      .get()
+      .then((snap) => setEvents(snap.docs.map((d) => ({ id: d.id, ...d.data() }))))
+  }, [])
+
+  return (
+    <div>
+      <h1>Dashboard</h1>
+      <ul>
+        {events.map((event) => (
+          <li key={event.id}>
+            <Link href={`/${event.id}/admin`}>{event.title}</Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+export default withAuth(Dashboard)

--- a/premium-event-ticketing/src/utils/formatDate.ts
+++ b/premium-event-ticketing/src/utils/formatDate.ts
@@ -1,0 +1,7 @@
+export function formatDate(date: Date): string {
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+}

--- a/premium-event-ticketing/src/utils/generateSlug.ts
+++ b/premium-event-ticketing/src/utils/generateSlug.ts
@@ -1,0 +1,6 @@
+export function generateSlug(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)+/g, '')
+}


### PR DESCRIPTION
## Summary
- add dynamic event page with CheckoutModal and Firestore data
- add per-event admin page guarded by Firebase Auth
- add site dashboard page
- handle ticket fulfillment via Stripe webhook
- create Firebase/Stripe utilities and helper functions

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_686e71db690083249715b72478009b60